### PR TITLE
Added a toolchain designation in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ application {
 }
 
 java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }


### PR DESCRIPTION
Adding in the toolchain designation fixed an issue I had on OpenSUSE Tumbleweed when trying to build/run the project. Without it, gradle just failed to build and claimed I didn't have javac installed, despite having all the appropriate packages for jdk and jdk-dev installed (both 21 and 17, just in case). Not sure why this change in particular fixed it, it should be essentially equivalent to sourceCompatibility and targetCompatibility which are already set properly. It might be because I wasn't setting up anything in an IDE and just running from a terminal, so there was an extra environment setting that needed to happen. At any rate, adding in these lines made it work as intended for me.