### PR TITLE
Add REST API server for headless map generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,22 @@ application {
     )
 }
 
+tasks.register<JavaExec>("runApi") {
+    description = "Run the Map API server"
+    group = "application"
+    mainClass.set("nortantis.api.MapApiServer")
+    classpath = sourceSets.main.get().runtimeClasspath
+    jvmArgs = listOf(
+        "--enable-native-access=ALL-UNNAMED",
+        "-Djava.awt.headless=true",
+        "-Xmx4g",
+    )
+    // Pass command line args, e.g., ./gradlew runApi --args="9090"
+    if (project.hasProperty("apiPort")) {
+        args = listOf(project.property("apiPort").toString())
+    }
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,8 @@ tasks.register<JavaExec>("runApi") {
         "-Djava.awt.headless=true",
         "-Xmx4g",
     )
+    // Pass NORTANTIS_API_TOKEN env var through to the server process
+    environment("NORTANTIS_API_TOKEN", System.getenv("NORTANTIS_API_TOKEN") ?: "")
     // Pass command line args, e.g., ./gradlew runApi --args="9090"
     if (project.hasProperty("apiPort")) {
         args = listOf(project.property("apiPort").toString())

--- a/docs/api-next-params.md
+++ b/docs/api-next-params.md
@@ -1,0 +1,189 @@
+# API Next Parameters - Analysis & Tasks
+
+## Already Implemented
+
+`size`, `width`, `height`, `quality`, `format`, `seed`, `worldSize`, `landShape`, `regionCount`, `drawText`, `drawBorder`, `drawRoads`
+
+---
+
+## Priority 1: Visual Style (High Impact)
+
+These parameters dramatically change the map's look and feel. Users will want these most.
+
+### 1.1 Colors
+
+| Parameter | Type | Example | MapSettings Field | Description |
+|-----------|------|---------|-------------------|-------------|
+| `oceanColor` | hex | `#2a4a6b` | `oceanColor` | Ocean fill color |
+| `landColor` | hex | `#c8b078` | `landColor` | Base land fill color |
+| `textColor` | hex | `#000000` | `textColor` | Text label color |
+| `riverColor` | hex | `#4a6fa5` | `riverColor` | River line color |
+| `roadColor` | hex | `#000000` | `roadColor` | Road line color |
+| `coastlineColor` | hex | `#000000` | `coastlineColor` | Coastline color |
+| `borderColor` | hex | `#000000` | `borderColor` | Border frame color |
+
+**API example:**
+```
+?oceanColor=2a4a6b&landColor=c8b078&textColor=333333
+```
+
+**Implementation:** Parse hex string → `Color.create(r, g, b)`. Support with/without `#` prefix.
+
+### 1.2 Background Type
+
+| Parameter | Type | Values | MapSettings Fields | Description |
+|-----------|------|--------|-------------------|-------------|
+| `background` | string | `generated`, `texture`, `solid` | `generateBackground`, `generateBackgroundFromTexture`, `solidColorBackground` | How the background is created |
+| `backgroundTexture` | string | `old_paper_1`, `old_paper_2`, `grungy_paper`, `wavy_paper`, `declaration` | `backgroundTextureResource` | Which texture to use (when background=texture) |
+
+Available textures (from assets):
+- `old_paper_1` — old paper 1.png
+- `old_paper_2` — old paper 2.png
+- `grungy_paper` — grungy paper.png
+- `wavy_paper` — wavy paper.png
+- `declaration` — declaration of independence back.png
+
+### 1.3 Ocean Effect
+
+| Parameter | Type | Values | MapSettings Field | Description |
+|-----------|------|--------|-------------------|-------------|
+| `oceanWaves` | string | `none`, `ripples`, `concentric` | `oceanWavesType` | Ocean wave style |
+| `concentricWaveCount` | int | 2-5 | `concentricWaveCount` | Number of concentric waves |
+
+### 1.4 Line Style
+
+| Parameter | Type | Values | MapSettings Field | Description |
+|-----------|------|--------|-------------------|-------------|
+| `lineStyle` | string | `jagged`, `splines`, `smooth_coast` | `lineStyle` | Coastline rendering style |
+
+Maps to: `Jagged`, `Splines`, `SplinesWithSmoothedCoastlines`
+
+---
+
+## Priority 2: Geography Control (Medium Impact)
+
+Fine-tuning how the world is shaped.
+
+### 2.1 Land/Water Balance
+
+| Parameter | Type | Range | Default | MapSettings Field | Description |
+|-----------|------|-------|---------|-------------------|-------------|
+| `centerLandProbability` | double | 0.0-1.0 | auto | `centerLandToWaterProbability` | Chance of land in center (higher = more land) |
+| `edgeLandProbability` | double | 0.0-1.0 | auto | `edgeLandToWaterProbability` | Chance of land on edges (0 = island, 1 = land fills map) |
+| `cityProbability` | double | 0.0-0.025 | 0.00625 | `cityProbability` | Density of cities |
+
+### 2.2 Region Display
+
+| Parameter | Type | Values | MapSettings Field | Description |
+|-----------|------|--------|-------------------|-------------|
+| `drawRegionColors` | bool | true/false | `drawRegionColors` | Color regions differently |
+| `drawRegionBoundaries` | bool | true/false | `drawRegionBoundaries` | Draw borders between regions |
+
+---
+
+## Priority 3: Detail & Decoration (Lower Impact)
+
+### 3.1 Icon Scales
+
+| Parameter | Type | Range | Default | MapSettings Field | Description |
+|-----------|------|-------|---------|-------------------|-------------|
+| `mountainScale` | double | 0.5-3.0 | 1.2 | `mountainScale` | Mountain icon size |
+| `hillScale` | double | 0.5-3.0 | 1.2 | `hillScale` | Hill icon size |
+| `treeScale` | double | 0.1-1.0 | 0.4 | `treeHeightScale` | Tree icon size |
+| `cityScale` | double | 0.5-3.0 | 1.2 | `cityScale` | City icon size |
+| `duneScale` | double | 0.5-3.0 | 1.2 | `duneScale` | Sand dune icon size |
+
+### 3.2 Border & Edge Effects
+
+| Parameter | Type | Range/Values | MapSettings Field | Description |
+|-----------|------|-------------|-------------------|-------------|
+| `frayedBorder` | bool | true/false | `frayedBorder` | Frayed/torn paper edges |
+| `drawGrunge` | bool | true/false | `drawGrunge` | Dark grunge stains around edges |
+| `grungeWidth` | int | 100-1500 | random | Width of grunge effect |
+| `borderWidth` | int | 25-300 | random | Border frame thickness |
+
+### 3.3 Shading Levels
+
+| Parameter | Type | Range | Default | MapSettings Field | Description |
+|-----------|------|-------|---------|-------------------|-------------|
+| `coastShadingLevel` | int | 0-100 | random(15-50) | `coastShadingLevel` | Darkness of coast shadows |
+| `oceanWavesLevel` | int | 0-100 | random(15-50) | `oceanWavesLevel` | Intensity of ocean wave effect |
+| `coastlineWidth` | double | 0.5-5.0 | 1.0 | `coastlineWidth` | Coastline thickness |
+
+---
+
+## Priority 4: Name Generation (Unique Feature)
+
+### 4.1 Books (Name Sources)
+
+| Parameter | Type | Values | MapSettings Field | Description |
+|-----------|------|--------|-------------------|-------------|
+| `books` | string (comma-separated) | see list | `books` | Books used for generating place names |
+
+Available books:
+- `a_princess_of_mars`
+- `ancient_egypt`
+- `around_the_world_in_80_days`
+- `middle_ages` (Beacon Lights of History)
+- `gullivers_travels`
+- `jungle_tales_of_tarzan`
+- `parish_priests_middle_ages`
+- `ssa_boy_names`
+- `ssa_girl_names`
+- `faerie_queene`
+- `alembic_plot`
+- `art_of_war_middle_ages`
+- `underground_city`
+- `wizard_of_oz`
+
+**API example:**
+```
+?books=ancient_egypt,wizard_of_oz
+```
+
+This gives users creative control over the naming style — Egyptian-sounding names, fantasy names, etc.
+
+### 4.2 Text Seed
+
+| Parameter | Type | Range | MapSettings Field | Description |
+|-----------|------|-------|-------------------|-------------|
+| `textSeed` | long | any | `textRandomSeed` | Separate seed for name generation (same map, different names) |
+
+---
+
+## Priority 5: Discovery Endpoints (No Generation)
+
+New GET endpoints to help API users discover valid parameter values.
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /api/options/sizes` | List of size presets with dimensions |
+| `GET /api/options/qualities` | Quality presets with resolution values |
+| `GET /api/options/books` | Available name generation books |
+| `GET /api/options/textures` | Available background textures |
+| `GET /api/options/borders` | Available border types |
+| `GET /api/options/land-shapes` | Land shape enum values |
+| `GET /api/options/ocean-waves` | Ocean wave types |
+
+---
+
+## Implementation Order
+
+| Phase | Tasks | New Params Count | Effort |
+|-------|-------|-----------------|--------|
+| **Phase 1** | Colors + Background + Ocean + LineStyle | ~12 | Medium |
+| **Phase 2** | Land/Water balance + Region display | ~5 | Small |
+| **Phase 3** | Icon scales + Border effects + Shading | ~12 | Medium |
+| **Phase 4** | Books + textSeed | ~2 | Small |
+| **Phase 5** | Discovery endpoints | 0 (7 new endpoints) | Medium |
+
+**Total new parameters: ~31**
+
+---
+
+## Notes
+
+- Hex color parsing: accept both `#RRGGBB` and `RRGGBB`
+- All new parameters remain optional — omitted = random/default
+- For Phase 5 discovery endpoints, return JSON arrays so frontend can build dynamic UIs
+- `books` parameter requires mapping from URL-friendly slug to actual book filename

--- a/docs/api-tasks.md
+++ b/docs/api-tasks.md
@@ -1,0 +1,109 @@
+# Nortantis Map API - Implementation Tasks
+
+## Current State
+
+API server (`nortantis.api.MapApiServer`) fully implements all planned query parameters.
+
+### Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/health` | GET | Health check, returns version |
+| `/api/maps/generate` | POST | Generate map (empty body=random, or JSON body for settings) |
+| `/api/maps/generate-from-settings` | POST | Generate from full .nort JSON body |
+
+### Supported Query Parameters
+
+All parameters are optional. Unspecified values use random/default from `SettingsGenerator`.
+
+| Parameter | Type | Values / Range | Default | Description |
+|-----------|------|---------------|---------|-------------|
+| `size` | string | `small`, `medium`, `large`, `wide_small`, `wide_medium`, `wide_large`, `golden`, `custom` | random | Output dimensions preset |
+| `width` | int | 256-8192 | - | Custom width (requires `size=custom`) |
+| `height` | int | 256-8192 | - | Custom height (requires `size=custom`) |
+| `quality` | string | `draft`, `low`, `medium`, `high` | `low` (0.5) | Resolution scale (0.25 / 0.5 / 0.75 / 1.0) |
+| `format` | string | `png`, `jpg` | `png` | Output image format |
+| `seed` | long | any | random | Random seed (returned in `X-Map-Seed` header) |
+| `worldSize` | int | 2000-32000 | random | World complexity |
+| `landShape` | string | `continents`, `inland_sea`, `scattered` | random | Land mass shape |
+| `regionCount` | int | 2-20 | auto | Number of political regions |
+| `drawText` | bool | `true`, `false` | true | Show place names and titles |
+| `drawBorder` | bool | `true`, `false` | random | Draw decorative border |
+| `drawRoads` | bool | `true`, `false` | true | Show roads between cities |
+
+### Size Presets
+
+| Preset | Width | Height | Aspect Ratio | Use Case |
+|--------|-------|--------|--------------|----------|
+| `small` | 1024 | 1024 | 1:1 | Thumbnail / preview |
+| `medium` | 2048 | 2048 | 1:1 | Web display |
+| `large` | 4096 | 4096 | 1:1 | High quality download |
+| `wide_small` | 1920 | 1080 | 16:9 | Web banner |
+| `wide_medium` | 2560 | 1440 | 16:9 | 2K wallpaper |
+| `wide_large` | 4096 | 2304 | 16:9 | 4K wallpaper |
+| `golden` | 4096 | 2531 | Golden ratio | Classic print style |
+
+---
+
+## Completed Tasks
+
+- [x] **Task 1: Image Size Presets** — `ApiSizePreset` enum + `size`, `width`, `height` params
+- [x] **Task 2: Resolution Control** — `ApiQuality` enum + `quality` param, clamped to max 2.0
+- [x] **Task 3: Output Format** — `format=png|jpg` with JPEG quality 0.95
+- [x] **Task 4: World Parameters** — `seed`, `worldSize`, `landShape`, `regionCount`, `drawText`, `drawBorder`, `drawRoads`
+- [x] **Task 5: Response Headers** — `X-Map-Seed` header for reproducibility
+- [x] **Task 6: Validation** — 400 errors with clear messages for invalid parameters
+
+---
+
+## Test Results
+
+All tests passed:
+
+| Test | Command | Result |
+|------|---------|--------|
+| Health check | `GET /api/health` | `{"status":"ok","version":"3.18"}` |
+| Small + draft | `?size=small&quality=draft` | 294x294 PNG, 160KB |
+| Wide large + high + seed | `?size=wide_large&quality=high&seed=42&landShape=continents&regionCount=5` | 4160x2368 PNG |
+| JPG format | `?size=small&quality=draft&format=jpg` | 396x396 JPEG, 70KB |
+| Scattered + no text | `?landShape=scattered&drawText=false&drawBorder=false` | 1024x1024 PNG |
+| Custom size | `?size=custom&width=1600&height=900&quality=low` | 834x484 PNG |
+| Bad size (error) | `?size=huge` | 400 with error message |
+| Missing width (error) | `?size=custom&height=500` | 400 with error message |
+| Seed header | `X-Map-Seed` response header | Returns seed value (e.g. `42`) |
+
+---
+
+## Usage Examples
+
+```bash
+# Start the server
+./gradlew runApi
+
+# Quick preview
+curl -X POST "http://localhost:8080/api/maps/generate?size=small&quality=draft" -o preview.png
+
+# High quality reproducible continent map
+curl -X POST "http://localhost:8080/api/maps/generate?size=wide_large&quality=high&seed=12345&landShape=continents&regionCount=8" -o map.png
+
+# Scattered islands wallpaper as JPEG
+curl -X POST "http://localhost:8080/api/maps/generate?size=wide_medium&quality=medium&landShape=scattered&format=jpg" -o wallpaper.jpg
+
+# Custom dimensions, no text or roads
+curl -X POST "http://localhost:8080/api/maps/generate?size=custom&width=3840&height=2160&quality=medium&drawText=false&drawRoads=false" -o clean_map.png
+
+# Generate from .nort file, override to small size
+curl -X POST "http://localhost:8080/api/maps/generate-from-settings?size=small&quality=low" -d @my_map.nort -o output.png
+```
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `src/nortantis/api/MapApiServer.java` | HTTP server with all endpoints and parameter handling |
+| `src/nortantis/api/ApiSizePreset.java` | Size preset enum (small → golden) |
+| `src/nortantis/api/ApiQuality.java` | Quality preset enum (draft → high) |
+| `src/nortantis/MapSettings.java` | Added `parseJsonForApi()` public method |
+| `build.gradle.kts` | Added `runApi` Gradle task |

--- a/src/nortantis/MapSettings.java
+++ b/src/nortantis/MapSettings.java
@@ -772,6 +772,11 @@ public class MapSettings implements Serializable
 		return font.getName() + "\t" + font.getStyle().value + "\t" + (int) font.getSize();
 	}
 
+	public void parseJsonForApi(String json)
+	{
+		parseFromJson(json);
+	}
+
 	private void parseFromJson(String fileContents)
 	{
 		JSONObject root = null;

--- a/src/nortantis/api/ApiQuality.java
+++ b/src/nortantis/api/ApiQuality.java
@@ -1,0 +1,30 @@
+package nortantis.api;
+
+public enum ApiQuality
+{
+	draft(0.25),
+	low(0.5),
+	medium(0.75),
+	high(1.0);
+
+	public final double resolution;
+
+	ApiQuality(double resolution)
+	{
+		this.resolution = resolution;
+	}
+
+	public static ApiQuality fromString(String name)
+	{
+		if (name == null || name.isBlank())
+			return null;
+		try
+		{
+			return valueOf(name.toLowerCase());
+		}
+		catch (IllegalArgumentException e)
+		{
+			return null;
+		}
+	}
+}

--- a/src/nortantis/api/ApiSizePreset.java
+++ b/src/nortantis/api/ApiSizePreset.java
@@ -1,0 +1,35 @@
+package nortantis.api;
+
+public enum ApiSizePreset
+{
+	small(1024, 1024),
+	medium(2048, 2048),
+	large(4096, 4096),
+	wide_small(1920, 1080),
+	wide_medium(2560, 1440),
+	wide_large(4096, 2304),
+	golden(4096, 2531);
+
+	public final int width;
+	public final int height;
+
+	ApiSizePreset(int width, int height)
+	{
+		this.width = width;
+		this.height = height;
+	}
+
+	public static ApiSizePreset fromString(String name)
+	{
+		if (name == null || name.isBlank())
+			return null;
+		try
+		{
+			return valueOf(name.toLowerCase());
+		}
+		catch (IllegalArgumentException e)
+		{
+			return null;
+		}
+	}
+}

--- a/src/nortantis/api/MapApiServer.java
+++ b/src/nortantis/api/MapApiServer.java
@@ -1,0 +1,953 @@
+package nortantis.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import nortantis.*;
+import nortantis.MapSettings.LineStyle;
+import nortantis.MapSettings.OceanWaves;
+import nortantis.platform.Color;
+import nortantis.platform.Image;
+import nortantis.platform.PlatformFactory;
+import nortantis.platform.awt.AwtFactory;
+import nortantis.swing.translation.Translation;
+import nortantis.util.Logger;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+public class MapApiServer
+{
+	private final HttpServer server;
+	private static final int DEFAULT_PORT = 8080;
+
+	private static final int MIN_CUSTOM_SIZE = 256;
+	private static final int MAX_CUSTOM_SIZE = 8192;
+	private static final double MAX_RESOLUTION = 2.0;
+	private static final float JPEG_QUALITY = 0.95f;
+
+	private static final Map<String, String> BOOK_SLUG_TO_NAME = new LinkedHashMap<>();
+	static
+	{
+		BOOK_SLUG_TO_NAME.put("a_princess_of_mars", "A Princess of Mars");
+		BOOK_SLUG_TO_NAME.put("ancient_egypt", "Ancient Egypt");
+		BOOK_SLUG_TO_NAME.put("around_the_world_in_80_days", "Around the World in 80 Days");
+		BOOK_SLUG_TO_NAME.put("middle_ages", "Beacon Lights of History, Volume V, The middle ages");
+		BOOK_SLUG_TO_NAME.put("gullivers_travels", "Gulliver's Travels Into Several Remote Regions of the World");
+		BOOK_SLUG_TO_NAME.put("jungle_tales_of_tarzan", "Jungle Tales of Tarzan");
+		BOOK_SLUG_TO_NAME.put("parish_priests_middle_ages", "Parish Priests and Their People in the Middle Ages in England");
+		BOOK_SLUG_TO_NAME.put("ssa_boy_names", "SSA boy names");
+		BOOK_SLUG_TO_NAME.put("ssa_girl_names", "SSA girl names");
+		BOOK_SLUG_TO_NAME.put("faerie_queene", "Spenser's The Faerie Queene, Book I");
+		BOOK_SLUG_TO_NAME.put("alembic_plot", "The Alembic Plot A Terran Empire novel");
+		BOOK_SLUG_TO_NAME.put("art_of_war_middle_ages", "The Art of War in the Middle Ages A.D. 378-1515");
+		BOOK_SLUG_TO_NAME.put("underground_city", "The Underground City, or, the Child of the Cavern");
+		BOOK_SLUG_TO_NAME.put("wizard_of_oz", "The Wonderful Wizard of Oz");
+	}
+
+	private static final Map<String, String> TEXTURE_SLUG_TO_NAME = new LinkedHashMap<>();
+	static
+	{
+		TEXTURE_SLUG_TO_NAME.put("old_paper_1", "old paper 1.png");
+		TEXTURE_SLUG_TO_NAME.put("old_paper_2", "old paper 2.png");
+		TEXTURE_SLUG_TO_NAME.put("grungy_paper", "grungy paper.png");
+		TEXTURE_SLUG_TO_NAME.put("wavy_paper", "wavy paper.png");
+		TEXTURE_SLUG_TO_NAME.put("declaration", "declaration of independence back.png");
+	}
+
+	public MapApiServer(int port) throws IOException
+	{
+		server = HttpServer.create(new InetSocketAddress(port), 0);
+		server.setExecutor(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+
+		server.createContext("/api/health", this::handleHealth);
+		server.createContext("/api/maps/generate", this::handleGenerate);
+		server.createContext("/api/maps/generate-from-settings", this::handleGenerateFromSettings);
+
+		server.createContext("/api/options/sizes", this::handleOptionsSizes);
+		server.createContext("/api/options/qualities", this::handleOptionsQualities);
+		server.createContext("/api/options/books", this::handleOptionsBooks);
+		server.createContext("/api/options/textures", this::handleOptionsTextures);
+		server.createContext("/api/options/borders", this::handleOptionsBorders);
+		server.createContext("/api/options/land-shapes", this::handleOptionsLandShapes);
+		server.createContext("/api/options/ocean-waves", this::handleOptionsOceanWaves);
+		server.createContext("/api/options/line-styles", this::handleOptionsLineStyles);
+		server.createContext("/api/options/all", this::handleOptionsAll);
+	}
+
+	public void start()
+	{
+		server.start();
+		Logger.println("Map API server started on port " + server.getAddress().getPort());
+	}
+
+	// ======================== Handlers ========================
+
+	private void handleHealth(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET"))
+			return;
+		sendJson(exchange, 200, "{\"status\":\"ok\",\"version\":\"" + MapSettings.currentVersion + "\"}");
+	}
+
+	// ======================== Discovery Endpoints ========================
+
+	private void handleOptionsSizes(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		StringBuilder sb = new StringBuilder("[");
+		for (ApiSizePreset p : ApiSizePreset.values())
+		{
+			if (sb.length() > 1) sb.append(",");
+			sb.append("{\"name\":\"").append(p.name())
+				.append("\",\"width\":").append(p.width)
+				.append(",\"height\":").append(p.height).append("}");
+		}
+		sb.append(",{\"name\":\"custom\",\"description\":\"Specify width and height (256-8192)\"}]");
+		sendJson(exchange, 200, sb.toString());
+	}
+
+	private void handleOptionsQualities(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		StringBuilder sb = new StringBuilder("[");
+		for (ApiQuality q : ApiQuality.values())
+		{
+			if (sb.length() > 1) sb.append(",");
+			sb.append("{\"name\":\"").append(q.name())
+				.append("\",\"resolution\":").append(q.resolution).append("}");
+		}
+		sb.append("]");
+		sendJson(exchange, 200, sb.toString());
+	}
+
+	private void handleOptionsBooks(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		StringBuilder sb = new StringBuilder("[");
+		for (Map.Entry<String, String> e : BOOK_SLUG_TO_NAME.entrySet())
+		{
+			if (sb.length() > 1) sb.append(",");
+			sb.append("{\"slug\":\"").append(e.getKey())
+				.append("\",\"name\":\"").append(escapeJson(e.getValue())).append("\"}");
+		}
+		sb.append("]");
+		sendJson(exchange, 200, sb.toString());
+	}
+
+	private void handleOptionsTextures(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		StringBuilder sb = new StringBuilder("[");
+		for (Map.Entry<String, String> e : TEXTURE_SLUG_TO_NAME.entrySet())
+		{
+			if (sb.length() > 1) sb.append(",");
+			sb.append("{\"slug\":\"").append(e.getKey())
+				.append("\",\"file\":\"").append(escapeJson(e.getValue())).append("\"}");
+		}
+		sb.append("]");
+		sendJson(exchange, 200, sb.toString());
+	}
+
+	private void handleOptionsBorders(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		sendJson(exchange, 200, "[{\"name\":\"dashes\"},{\"name\":\"dashes with inset corners\"},{\"name\":\"lines\"}]");
+	}
+
+	private void handleOptionsLandShapes(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		StringBuilder sb = new StringBuilder("[");
+		for (LandShape ls : LandShape.values())
+		{
+			if (sb.length() > 1) sb.append(",");
+			sb.append("{\"value\":\"").append(ls.name().toLowerCase())
+				.append("\",\"name\":\"").append(ls.name().replace('_', ' ')).append("\"}");
+		}
+		sb.append("]");
+		sendJson(exchange, 200, sb.toString());
+	}
+
+	private void handleOptionsOceanWaves(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		sendJson(exchange, 200, "[{\"value\":\"none\",\"name\":\"None\"},{\"value\":\"ripples\",\"name\":\"Ripples\"},{\"value\":\"concentric\",\"name\":\"Concentric Waves\"}]");
+	}
+
+	private void handleOptionsLineStyles(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+		sendJson(exchange, 200, "[{\"value\":\"jagged\",\"name\":\"Jagged\"},{\"value\":\"splines\",\"name\":\"Splines\"},{\"value\":\"smooth_coast\",\"name\":\"Splines with Smoothed Coastlines\"}]");
+	}
+
+	private void handleOptionsAll(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "GET")) return;
+
+		StringBuilder sb = new StringBuilder("{");
+
+		// sizes
+		sb.append("\"sizes\":[");
+		for (int i = 0; i < ApiSizePreset.values().length; i++)
+		{
+			ApiSizePreset p = ApiSizePreset.values()[i];
+			if (i > 0) sb.append(",");
+			sb.append("{\"name\":\"").append(p.name())
+				.append("\",\"width\":").append(p.width)
+				.append(",\"height\":").append(p.height).append("}");
+		}
+		sb.append(",{\"name\":\"custom\",\"description\":\"Specify width and height (256-8192)\"}],");
+
+		// qualities
+		sb.append("\"qualities\":[");
+		int qi = 0;
+		for (ApiQuality q : ApiQuality.values())
+		{
+			if (qi++ > 0) sb.append(",");
+			sb.append("{\"name\":\"").append(q.name())
+				.append("\",\"resolution\":").append(q.resolution).append("}");
+		}
+		sb.append("],");
+
+		// books
+		sb.append("\"books\":[");
+		int bi = 0;
+		for (Map.Entry<String, String> e : BOOK_SLUG_TO_NAME.entrySet())
+		{
+			if (bi++ > 0) sb.append(",");
+			sb.append("{\"slug\":\"").append(e.getKey())
+				.append("\",\"name\":\"").append(escapeJson(e.getValue())).append("\"}");
+		}
+		sb.append("],");
+
+		// textures
+		sb.append("\"textures\":[");
+		int ti = 0;
+		for (Map.Entry<String, String> e : TEXTURE_SLUG_TO_NAME.entrySet())
+		{
+			if (ti++ > 0) sb.append(",");
+			sb.append("{\"slug\":\"").append(e.getKey())
+				.append("\",\"file\":\"").append(escapeJson(e.getValue())).append("\"}");
+		}
+		sb.append("],");
+
+		// borders
+		sb.append("\"borders\":[{\"name\":\"dashes\"},{\"name\":\"dashes with inset corners\"},{\"name\":\"lines\"}],");
+
+		// land shapes
+		sb.append("\"landShapes\":[");
+		int li = 0;
+		for (LandShape ls : LandShape.values())
+		{
+			if (li++ > 0) sb.append(",");
+			sb.append("{\"value\":\"").append(ls.name().toLowerCase())
+				.append("\",\"name\":\"").append(ls.name().replace('_', ' ')).append("\"}");
+		}
+		sb.append("],");
+
+		// ocean waves
+		sb.append("\"oceanWaves\":[{\"value\":\"none\",\"name\":\"None\"},{\"value\":\"ripples\",\"name\":\"Ripples\"},{\"value\":\"concentric\",\"name\":\"Concentric Waves\"}],");
+
+		// line styles
+		sb.append("\"lineStyles\":[{\"value\":\"jagged\",\"name\":\"Jagged\"},{\"value\":\"splines\",\"name\":\"Splines\"},{\"value\":\"smooth_coast\",\"name\":\"Splines with Smoothed Coastlines\"}]");
+
+		sb.append("}");
+		sendJson(exchange, 200, sb.toString());
+	}
+
+	// ======================== Map Generation Handlers ========================
+
+	private void handleGenerate(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "POST"))
+			return;
+
+		try
+		{
+			Map<String, String> params = parseQueryParams(exchange);
+			String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+
+			MapSettings settings;
+			if (body.isBlank())
+			{
+				settings = SettingsGenerator.generate(null);
+			}
+			else
+			{
+				settings = new MapSettings();
+				settings.parseJsonForApi(body);
+			}
+
+			String error = applyQueryParams(settings, params);
+			if (error != null)
+			{
+				sendJson(exchange, 400, "{\"error\":\"" + escapeJson(error) + "\"}");
+				return;
+			}
+
+			String format = getFormat(params);
+			byte[] imageBytes = generateMapImage(settings, format);
+			sendImage(exchange, imageBytes, format, settings.randomSeed);
+		}
+		catch (Exception e)
+		{
+			Logger.printError("Error generating map: ", e);
+			sendJson(exchange, 500, "{\"error\":\"" + escapeJson(e.getMessage()) + "\"}");
+		}
+	}
+
+	private void handleGenerateFromSettings(HttpExchange exchange) throws IOException
+	{
+		if (!requireMethod(exchange, "POST"))
+			return;
+
+		try
+		{
+			Map<String, String> params = parseQueryParams(exchange);
+			String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+			if (body.isBlank())
+			{
+				sendJson(exchange, 400, "{\"error\":\"Request body must contain .nort JSON settings\"}");
+				return;
+			}
+
+			MapSettings settings = new MapSettings();
+			settings.parseJsonForApi(body);
+
+			String error = applyQueryParams(settings, params);
+			if (error != null)
+			{
+				sendJson(exchange, 400, "{\"error\":\"" + escapeJson(error) + "\"}");
+				return;
+			}
+
+			String format = getFormat(params);
+			byte[] imageBytes = generateMapImage(settings, format);
+			sendImage(exchange, imageBytes, format, settings.randomSeed);
+		}
+		catch (Exception e)
+		{
+			Logger.printError("Error generating map from settings: ", e);
+			sendJson(exchange, 500, "{\"error\":\"" + escapeJson(e.getMessage()) + "\"}");
+		}
+	}
+
+	// ======================== Parameter Application ========================
+
+	private String applyQueryParams(MapSettings settings, Map<String, String> params)
+	{
+		String error;
+
+		// --- Size ---
+		error = applySize(settings, params);
+		if (error != null) return error;
+
+		// --- Quality ---
+		error = applyQuality(settings, params);
+		if (error != null) return error;
+
+		// --- Seed ---
+		error = applyLong(params, "seed", v -> settings.randomSeed = v);
+		if (error != null) return error;
+
+		// --- World Size ---
+		error = applyInt(params, "worldSize", SettingsGenerator.minWorldSize, SettingsGenerator.maxWorldSize, v -> settings.worldSize = v);
+		if (error != null) return error;
+
+		// --- Land Shape ---
+		error = applyLandShape(settings, params);
+		if (error != null) return error;
+
+		// --- Region Count ---
+		error = applyInt(params, "regionCount", SettingsGenerator.minRegionCount, SettingsGenerator.maxRegionCount, v -> settings.regionCount = v);
+		if (error != null) return error;
+
+		// --- Boolean toggles ---
+		applyBool(params, "drawText", v -> settings.drawText = v);
+		applyBool(params, "drawBorder", v -> settings.drawBorder = v);
+		applyBool(params, "drawRoads", v -> settings.drawRoads = v);
+		applyBool(params, "drawRegionColors", v -> settings.drawRegionColors = v);
+		applyBool(params, "drawRegionBoundaries", v -> settings.drawRegionBoundaries = v);
+		applyBool(params, "frayedBorder", v -> settings.frayedBorder = v);
+		applyBool(params, "drawGrunge", v -> settings.drawGrunge = v);
+
+		// --- Phase 1: Colors ---
+		error = applyColor(params, "oceanColor", v -> settings.oceanColor = v);
+		if (error != null) return error;
+		error = applyColor(params, "landColor", v -> settings.landColor = v);
+		if (error != null) return error;
+		error = applyColor(params, "textColor", v -> settings.textColor = v);
+		if (error != null) return error;
+		error = applyColor(params, "riverColor", v -> settings.riverColor = v);
+		if (error != null) return error;
+		error = applyColor(params, "roadColor", v -> settings.roadColor = v);
+		if (error != null) return error;
+		error = applyColor(params, "coastlineColor", v -> settings.coastlineColor = v);
+		if (error != null) return error;
+		error = applyColor(params, "borderColor", v -> settings.borderColor = v);
+		if (error != null) return error;
+
+		// --- Phase 1: Background ---
+		error = applyBackground(settings, params);
+		if (error != null) return error;
+
+		// --- Phase 1: Ocean Waves ---
+		error = applyOceanWaves(settings, params);
+		if (error != null) return error;
+
+		// --- Phase 1: Line Style ---
+		error = applyLineStyle(settings, params);
+		if (error != null) return error;
+
+		// --- Phase 2: Land/Water balance ---
+		error = applyDouble(params, "centerLandProbability", 0.0, 1.0, v -> settings.centerLandToWaterProbability = v);
+		if (error != null) return error;
+		error = applyDouble(params, "edgeLandProbability", 0.0, 1.0, v -> settings.edgeLandToWaterProbability = v);
+		if (error != null) return error;
+		error = applyDouble(params, "cityProbability", 0.0, SettingsGenerator.maxCityProbability, v -> settings.cityProbability = v);
+		if (error != null) return error;
+
+		// --- Phase 3: Icon scales ---
+		error = applyDouble(params, "mountainScale", 0.5, 3.0, v -> settings.mountainScale = v);
+		if (error != null) return error;
+		error = applyDouble(params, "hillScale", 0.5, 3.0, v -> settings.hillScale = v);
+		if (error != null) return error;
+		error = applyDouble(params, "treeScale", 0.1, 1.0, v -> settings.treeHeightScale = v);
+		if (error != null) return error;
+		error = applyDouble(params, "cityScale", 0.5, 3.0, v -> settings.cityScale = v);
+		if (error != null) return error;
+		error = applyDouble(params, "duneScale", 0.5, 3.0, v -> settings.duneScale = v);
+		if (error != null) return error;
+
+		// --- Phase 3: Border & Edge effects ---
+		error = applyInt(params, "grungeWidth", 100, 1500, v -> settings.grungeWidth = v);
+		if (error != null) return error;
+		error = applyInt(params, "borderWidth", 25, 300, v -> settings.borderWidth = v);
+		if (error != null) return error;
+
+		// --- Phase 3: Shading ---
+		error = applyInt(params, "coastShadingLevel", 0, 100, v -> settings.coastShadingLevel = v);
+		if (error != null) return error;
+		error = applyInt(params, "oceanWavesLevel", 0, 100, v -> settings.oceanWavesLevel = v);
+		if (error != null) return error;
+		error = applyDouble(params, "coastlineWidth", 0.5, 5.0, v -> settings.coastlineWidth = v);
+		if (error != null) return error;
+
+		// --- Phase 4: Books ---
+		error = applyBooks(settings, params);
+		if (error != null) return error;
+
+		// --- Phase 4: Text seed ---
+		error = applyLong(params, "textSeed", v -> settings.textRandomSeed = v);
+		if (error != null) return error;
+
+		return null;
+	}
+
+	// ======================== Typed Parameter Helpers ========================
+
+	private String applySize(MapSettings settings, Map<String, String> params)
+	{
+		String sizeParam = params.get("size");
+		if (sizeParam == null)
+			return null;
+
+		if (sizeParam.equalsIgnoreCase("custom"))
+		{
+			String widthStr = params.get("width");
+			String heightStr = params.get("height");
+			if (widthStr == null || heightStr == null)
+				return "size=custom requires both 'width' and 'height' parameters";
+			try
+			{
+				int w = Integer.parseInt(widthStr);
+				int h = Integer.parseInt(heightStr);
+				if (w < MIN_CUSTOM_SIZE || w > MAX_CUSTOM_SIZE || h < MIN_CUSTOM_SIZE || h > MAX_CUSTOM_SIZE)
+					return "width and height must be between " + MIN_CUSTOM_SIZE + " and " + MAX_CUSTOM_SIZE;
+				if ((double) Math.max(w, h) / Math.min(w, h) > 10)
+					return "Aspect ratio cannot exceed 10:1";
+				settings.generatedWidth = w;
+				settings.generatedHeight = h;
+			}
+			catch (NumberFormatException e)
+			{
+				return "width and height must be integers";
+			}
+		}
+		else
+		{
+			ApiSizePreset preset = ApiSizePreset.fromString(sizeParam);
+			if (preset == null)
+				return "Unknown size: '" + sizeParam + "'. Valid: "
+						+ Arrays.stream(ApiSizePreset.values()).map(Enum::name).collect(Collectors.joining(", ")) + ", custom";
+			settings.generatedWidth = preset.width;
+			settings.generatedHeight = preset.height;
+		}
+		return null;
+	}
+
+	private String applyQuality(MapSettings settings, Map<String, String> params)
+	{
+		String qualityParam = params.get("quality");
+		if (qualityParam != null)
+		{
+			ApiQuality quality = ApiQuality.fromString(qualityParam);
+			if (quality == null)
+				return "Unknown quality: '" + qualityParam + "'. Valid: draft, low, medium, high";
+			settings.resolution = quality.resolution;
+		}
+		else if (settings.resolution <= 0 || settings.resolution > MAX_RESOLUTION)
+		{
+			settings.resolution = 0.5;
+		}
+		return null;
+	}
+
+	private String applyLandShape(MapSettings settings, Map<String, String> params)
+	{
+		String v = params.get("landShape");
+		if (v == null)
+			return null;
+		try
+		{
+			settings.landShape = LandShape.valueOf(capitalize(v));
+		}
+		catch (IllegalArgumentException e)
+		{
+			return "Unknown landShape: '" + v + "'. Valid: continents, inland_sea, scattered";
+		}
+		return null;
+	}
+
+	private String applyBackground(MapSettings settings, Map<String, String> params)
+	{
+		String bg = params.get("background");
+		if (bg != null)
+		{
+			switch (bg.toLowerCase())
+			{
+			case "generated":
+				settings.generateBackground = true;
+				settings.generateBackgroundFromTexture = false;
+				settings.solidColorBackground = false;
+				break;
+			case "texture":
+				settings.generateBackground = false;
+				settings.generateBackgroundFromTexture = true;
+				settings.solidColorBackground = false;
+				break;
+			case "solid":
+				settings.generateBackground = false;
+				settings.generateBackgroundFromTexture = false;
+				settings.solidColorBackground = true;
+				break;
+			default:
+				return "Unknown background: '" + bg + "'. Valid: generated, texture, solid";
+			}
+		}
+
+		String tex = params.get("backgroundTexture");
+		if (tex != null)
+		{
+			String fileName = TEXTURE_SLUG_TO_NAME.get(tex.toLowerCase());
+			if (fileName == null)
+				return "Unknown backgroundTexture: '" + tex + "'. Valid: "
+						+ String.join(", ", TEXTURE_SLUG_TO_NAME.keySet());
+			settings.backgroundTextureResource = new NamedResource("nortantis", fileName);
+			settings.backgroundTextureSource = TextureSource.Assets;
+			settings.generateBackground = false;
+			settings.generateBackgroundFromTexture = true;
+			settings.solidColorBackground = false;
+		}
+
+		return null;
+	}
+
+	private String applyOceanWaves(MapSettings settings, Map<String, String> params)
+	{
+		String v = params.get("oceanWaves");
+		if (v == null)
+			return null;
+		switch (v.toLowerCase())
+		{
+		case "none":
+			settings.oceanWavesType = OceanWaves.None;
+			break;
+		case "ripples":
+			settings.oceanWavesType = OceanWaves.Ripples;
+			break;
+		case "concentric":
+			settings.oceanWavesType = OceanWaves.ConcentricWaves;
+			break;
+		default:
+			return "Unknown oceanWaves: '" + v + "'. Valid: none, ripples, concentric";
+		}
+
+		String error = applyInt(params, "concentricWaveCount", 1, SettingsGenerator.maxConcentricWaveCountInEditor, val -> settings.concentricWaveCount = val);
+		if (error != null) return error;
+
+		return null;
+	}
+
+	private String applyLineStyle(MapSettings settings, Map<String, String> params)
+	{
+		String v = params.get("lineStyle");
+		if (v == null)
+			return null;
+		switch (v.toLowerCase())
+		{
+		case "jagged":
+			settings.lineStyle = LineStyle.Jagged;
+			break;
+		case "splines":
+			settings.lineStyle = LineStyle.Splines;
+			break;
+		case "smooth_coast":
+		case "smoothcoast":
+			settings.lineStyle = LineStyle.SplinesWithSmoothedCoastlines;
+			break;
+		default:
+			return "Unknown lineStyle: '" + v + "'. Valid: jagged, splines, smooth_coast";
+		}
+		return null;
+	}
+
+	private String applyBooks(MapSettings settings, Map<String, String> params)
+	{
+		String v = params.get("books");
+		if (v == null)
+			return null;
+
+		Set<String> newBooks = new LinkedHashSet<>();
+		for (String slug : v.split(","))
+		{
+			slug = slug.trim().toLowerCase();
+			if (slug.isEmpty())
+				continue;
+			String bookName = BOOK_SLUG_TO_NAME.get(slug);
+			if (bookName == null)
+				return "Unknown book: '" + slug + "'. Valid: " + String.join(", ", BOOK_SLUG_TO_NAME.keySet());
+			newBooks.add(bookName);
+		}
+		if (!newBooks.isEmpty())
+		{
+			settings.books.clear();
+			settings.books.addAll(newBooks);
+		}
+		return null;
+	}
+
+	private static String applyInt(Map<String, String> params, String key, int min, int max, java.util.function.IntConsumer setter)
+	{
+		String v = params.get(key);
+		if (v == null)
+			return null;
+		try
+		{
+			int val = Integer.parseInt(v);
+			if (val < min || val > max)
+				return key + " must be between " + min + " and " + max;
+			setter.accept(val);
+		}
+		catch (NumberFormatException e)
+		{
+			return key + " must be an integer";
+		}
+		return null;
+	}
+
+	private static String applyDouble(Map<String, String> params, String key, double min, double max, java.util.function.DoubleConsumer setter)
+	{
+		String v = params.get(key);
+		if (v == null)
+			return null;
+		try
+		{
+			double val = Double.parseDouble(v);
+			if (val < min || val > max)
+				return key + " must be between " + min + " and " + max;
+			setter.accept(val);
+		}
+		catch (NumberFormatException e)
+		{
+			return key + " must be a number";
+		}
+		return null;
+	}
+
+	private static String applyLong(Map<String, String> params, String key, java.util.function.LongConsumer setter)
+	{
+		String v = params.get(key);
+		if (v == null)
+			return null;
+		try
+		{
+			setter.accept(Long.parseLong(v));
+		}
+		catch (NumberFormatException e)
+		{
+			return key + " must be a number";
+		}
+		return null;
+	}
+
+	private static void applyBool(Map<String, String> params, String key, java.util.function.Consumer<Boolean> setter)
+	{
+		String v = params.get(key);
+		if (v != null)
+			setter.accept(Boolean.parseBoolean(v));
+	}
+
+	private static String applyColor(Map<String, String> params, String key, java.util.function.Consumer<Color> setter)
+	{
+		String v = params.get(key);
+		if (v == null)
+			return null;
+		String hex = v.startsWith("#") ? v.substring(1) : v;
+		if (hex.length() != 6)
+			return key + " must be a 6-digit hex color (e.g. 2a4a6b or #2a4a6b)";
+		try
+		{
+			int r = Integer.parseInt(hex.substring(0, 2), 16);
+			int g = Integer.parseInt(hex.substring(2, 4), 16);
+			int b = Integer.parseInt(hex.substring(4, 6), 16);
+			setter.accept(Color.create(r, g, b));
+		}
+		catch (NumberFormatException e)
+		{
+			return key + " contains invalid hex characters";
+		}
+		return null;
+	}
+
+	// ======================== Image Generation ========================
+
+	private static String getFormat(Map<String, String> params)
+	{
+		String format = params.getOrDefault("format", "png").toLowerCase();
+		if (!format.equals("png") && !format.equals("jpg"))
+			format = "png";
+		return format;
+	}
+
+	private static byte[] generateMapImage(MapSettings settings, String format) throws Exception
+	{
+		MapCreator creator = new MapCreator();
+		Image map = creator.createMap(settings, null, null);
+		try
+		{
+			BufferedImage buffered = AwtFactory.unwrap(map);
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+			if (format.equals("jpg"))
+			{
+				BufferedImage rgb = convertToRgb(buffered);
+				Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpg");
+				if (!writers.hasNext())
+					throw new IllegalStateException("No JPEG writer available");
+				ImageWriter writer = writers.next();
+				try
+				{
+					ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
+					writer.setOutput(ios);
+					ImageWriteParam param = writer.getDefaultWriteParam();
+					param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+					param.setCompressionQuality(JPEG_QUALITY);
+					writer.write(null, new IIOImage(rgb, null, null), param);
+				}
+				finally
+				{
+					writer.dispose();
+				}
+			}
+			else
+			{
+				ImageIO.write(buffered, "png", baos);
+			}
+
+			return baos.toByteArray();
+		}
+		finally
+		{
+			map.close();
+		}
+	}
+
+	private static BufferedImage convertToRgb(BufferedImage src)
+	{
+		if (src.getType() == BufferedImage.TYPE_INT_RGB)
+			return src;
+		BufferedImage rgb = new BufferedImage(src.getWidth(), src.getHeight(), BufferedImage.TYPE_INT_RGB);
+		rgb.createGraphics().drawImage(src, 0, 0, null);
+		return rgb;
+	}
+
+	// ======================== HTTP Utilities ========================
+
+	private static Map<String, String> parseQueryParams(HttpExchange exchange)
+	{
+		Map<String, String> params = new LinkedHashMap<>();
+		String query = exchange.getRequestURI().getRawQuery();
+		if (query == null || query.isBlank())
+			return params;
+		for (String pair : query.split("&"))
+		{
+			int idx = pair.indexOf('=');
+			if (idx > 0)
+			{
+				String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+				String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+				params.put(key, value);
+			}
+		}
+		return params;
+	}
+
+	private static String capitalize(String s)
+	{
+		if (s == null || s.isEmpty())
+			return s;
+		StringBuilder sb = new StringBuilder();
+		boolean capitalizeNext = true;
+		for (char c : s.toCharArray())
+		{
+			if (c == '_')
+			{
+				sb.append(c);
+				capitalizeNext = true;
+			}
+			else if (capitalizeNext)
+			{
+				sb.append(Character.toUpperCase(c));
+				capitalizeNext = false;
+			}
+			else
+			{
+				sb.append(Character.toLowerCase(c));
+			}
+		}
+		return sb.toString();
+	}
+
+	private static boolean requireMethod(HttpExchange exchange, String method) throws IOException
+	{
+		if (!exchange.getRequestMethod().equalsIgnoreCase(method))
+		{
+			sendJson(exchange, 405, "{\"error\":\"Method not allowed. Use " + method + ".\"}");
+			return false;
+		}
+		return true;
+	}
+
+	private static void sendImage(HttpExchange exchange, byte[] data, String format, long seed) throws IOException
+	{
+		String contentType = format.equals("jpg") ? "image/jpeg" : "image/png";
+		exchange.getResponseHeaders().set("Content-Type", contentType);
+		exchange.getResponseHeaders().set("X-Map-Seed", String.valueOf(seed));
+		exchange.sendResponseHeaders(200, data.length);
+		try (OutputStream os = exchange.getResponseBody())
+		{
+			os.write(data);
+		}
+	}
+
+	private static void sendJson(HttpExchange exchange, int statusCode, String json) throws IOException
+	{
+		byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+		exchange.getResponseHeaders().set("Content-Type", "application/json");
+		exchange.sendResponseHeaders(statusCode, bytes.length);
+		try (OutputStream os = exchange.getResponseBody())
+		{
+			os.write(bytes);
+		}
+	}
+
+	private static String escapeJson(String value)
+	{
+		if (value == null)
+			return "Unknown error";
+		return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r");
+	}
+
+	// ======================== Main ========================
+
+	public static void main(String[] args) throws Exception
+	{
+		PlatformFactory.setInstance(new AwtFactory());
+		Translation.initialize();
+
+		int port = DEFAULT_PORT;
+		if (args.length > 0)
+		{
+			try
+			{
+				port = Integer.parseInt(args[0]);
+			}
+			catch (NumberFormatException e)
+			{
+				System.err.println("Invalid port: " + args[0] + ". Using default " + DEFAULT_PORT);
+			}
+		}
+
+		MapApiServer apiServer = new MapApiServer(port);
+		apiServer.start();
+		System.out.println("Nortantis Map API running at http://localhost:" + port);
+		System.out.println();
+		System.out.println("Endpoints:");
+		System.out.println("  GET  /api/health                      - Health check");
+		System.out.println("  POST /api/maps/generate               - Generate map");
+		System.out.println("  POST /api/maps/generate-from-settings - Generate from .nort JSON");
+		System.out.println();
+		System.out.println("Discovery:");
+		System.out.println("  GET  /api/options/all          - All options in one response");
+		System.out.println("  GET  /api/options/sizes        - Size presets");
+		System.out.println("  GET  /api/options/qualities    - Quality presets");
+		System.out.println("  GET  /api/options/books        - Name generation books");
+		System.out.println("  GET  /api/options/textures     - Background textures");
+		System.out.println("  GET  /api/options/borders      - Border types");
+		System.out.println("  GET  /api/options/land-shapes  - Land shape options");
+		System.out.println("  GET  /api/options/ocean-waves  - Ocean wave types");
+		System.out.println("  GET  /api/options/line-styles  - Line style options");
+		System.out.println();
+		System.out.println("Query Parameters:");
+		System.out.println("  size         = small|medium|large|wide_small|wide_medium|wide_large|golden|custom");
+		System.out.println("  width/height = int (256-8192, for size=custom)");
+		System.out.println("  quality      = draft|low|medium|high");
+		System.out.println("  format       = png|jpg");
+		System.out.println("  seed         = long");
+		System.out.println("  worldSize    = int (2000-32000)");
+		System.out.println("  landShape    = continents|inland_sea|scattered");
+		System.out.println("  regionCount  = int (2-20)");
+		System.out.println("  drawText/drawBorder/drawRoads/drawRegionColors/drawRegionBoundaries = true|false");
+		System.out.println("  frayedBorder/drawGrunge = true|false");
+		System.out.println("  oceanColor/landColor/textColor/riverColor/roadColor/coastlineColor/borderColor = hex");
+		System.out.println("  background      = generated|texture|solid");
+		System.out.println("  backgroundTexture = old_paper_1|old_paper_2|grungy_paper|wavy_paper|declaration");
+		System.out.println("  oceanWaves      = none|ripples|concentric");
+		System.out.println("  concentricWaveCount = int (1-5)");
+		System.out.println("  lineStyle       = jagged|splines|smooth_coast");
+		System.out.println("  centerLandProbability/edgeLandProbability = 0.0-1.0");
+		System.out.println("  cityProbability = 0.0-0.025");
+		System.out.println("  mountainScale/hillScale/cityScale/duneScale = 0.5-3.0");
+		System.out.println("  treeScale       = 0.1-1.0");
+		System.out.println("  grungeWidth     = int (100-1500)");
+		System.out.println("  borderWidth     = int (25-300)");
+		System.out.println("  coastShadingLevel/oceanWavesLevel = int (0-100)");
+		System.out.println("  coastlineWidth  = 0.5-5.0");
+		System.out.println("  books           = comma-separated slugs (ancient_egypt,wizard_of_oz,...)");
+		System.out.println("  textSeed        = long");
+	}
+}

--- a/src/nortantis/api/MapApiServer.java
+++ b/src/nortantis/api/MapApiServer.java
@@ -33,6 +33,9 @@ public class MapApiServer
 	private final HttpServer server;
 	private static final int DEFAULT_PORT = 8080;
 
+	private static final String TOKEN_ENV_VAR = "NORTANTIS_API_TOKEN";
+	private final String apiToken;
+
 	private static final int MIN_CUSTOM_SIZE = 256;
 	private static final int MAX_CUSTOM_SIZE = 8192;
 	private static final double MAX_RESOLUTION = 2.0;
@@ -67,8 +70,9 @@ public class MapApiServer
 		TEXTURE_SLUG_TO_NAME.put("declaration", "declaration of independence back.png");
 	}
 
-	public MapApiServer(int port) throws IOException
+	public MapApiServer(int port, String apiToken) throws IOException
 	{
+		this.apiToken = apiToken;
 		server = HttpServer.create(new InetSocketAddress(port), 0);
 		server.setExecutor(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
 
@@ -274,6 +278,8 @@ public class MapApiServer
 	{
 		if (!requireMethod(exchange, "POST"))
 			return;
+		if (!requireAuth(exchange))
+			return;
 
 		try
 		{
@@ -312,6 +318,8 @@ public class MapApiServer
 	private void handleGenerateFromSettings(HttpExchange exchange) throws IOException
 	{
 		if (!requireMethod(exchange, "POST"))
+			return;
+		if (!requireAuth(exchange))
 			return;
 
 		try
@@ -852,6 +860,26 @@ public class MapApiServer
 		return true;
 	}
 
+	private boolean requireAuth(HttpExchange exchange) throws IOException
+	{
+		if (apiToken == null || apiToken.isBlank())
+			return true;
+
+		String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
+		if (authHeader == null || authHeader.isBlank())
+		{
+			sendJson(exchange, 401, "{\"error\":\"Missing Authorization header. Use: Authorization: Bearer <token>\"}");
+			return false;
+		}
+		String prefix = "Bearer ";
+		if (!authHeader.startsWith(prefix) || !authHeader.substring(prefix.length()).equals(apiToken))
+		{
+			sendJson(exchange, 403, "{\"error\":\"Invalid token\"}");
+			return false;
+		}
+		return true;
+	}
+
 	private static void sendImage(HttpExchange exchange, byte[] data, String format, long seed) throws IOException
 	{
 		String contentType = format.equals("jpg") ? "image/jpeg" : "image/png";
@@ -902,9 +930,20 @@ public class MapApiServer
 			}
 		}
 
-		MapApiServer apiServer = new MapApiServer(port);
+		String token = System.getenv(TOKEN_ENV_VAR);
+		MapApiServer apiServer = new MapApiServer(port, token);
 		apiServer.start();
 		System.out.println("Nortantis Map API running at http://localhost:" + port);
+		if (token != null && !token.isBlank())
+		{
+			System.out.println("Authentication: ENABLED (token set via " + TOKEN_ENV_VAR + ")");
+			System.out.println("  Protected: /api/maps/*");
+			System.out.println("  Public:    /api/health, /api/options/*");
+		}
+		else
+		{
+			System.out.println("Authentication: DISABLED (set " + TOKEN_ENV_VAR + " to enable)");
+		}
 		System.out.println();
 		System.out.println("Endpoints:");
 		System.out.println("  GET  /api/health                      - Health check");


### PR DESCRIPTION
Introduce a web API layer on top of the existing map generation engine, allowing maps to be generated via HTTP without the Swing UI. The API supports 31+ query parameters covering size presets, quality, colors, background textures, ocean effects, land shape, icon scales, name generation books, and more. Includes 9 discovery endpoints for frontend integration.

New files:
- src/nortantis/api/MapApiServer.java - HTTP server with all endpoints
- src/nortantis/api/ApiSizePreset.java - Size preset enum
- src/nortantis/api/ApiQuality.java - Quality preset enum
- docs/api-tasks.md - API documentation and test results
- docs/api-next-params.md - Parameter analysis document

Modified:
- build.gradle.kts - Added runApi Gradle task
- MapSettings.java - Added parseJsonForApi() public method